### PR TITLE
added docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,14 @@ npx @milkshakeio/webidl2ts -e -d -n PhysX -i PhysX/physx/source/webidlbindings/s
 
 ```
 # Build the image
-docker build . -t physx-js-builder
-
-# Generate build-scripts
-docker run --rm -it -v $(pwd):/src physx-js-builder /bin/bash -c ./generate.sh
+docker compose up
 
 # Build Release
-docker run --rm -it -v $(pwd):/src physx-js-builder /bin/bash -c ./make.sh
+docker compose run --rm builder ./make.sh
 
 # Build Profile
-docker run --rm -it -v $(pwd):/src physx-js-builder /bin/bash -c ./make-profile.sh
+docker compose run --rm builder ./make-profile.sh
 
 # Build Debug
-docker run --rm -it -v $(pwd):/src physx-js-builder /bin/bash -c ./make-debug.sh
+docker compose run --rm builder ./make-debug.sh
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  builder:
+    build: .
+    volumes:
+      - .:/src
+      - packman:/root/packman-repo
+    entrypoint: ["bash",  "-c"]
+    command: ./generate.sh
+
+volumes:
+  packman:


### PR DESCRIPTION
I had some issues with the build process due to /root/packman-repo not being persistent across command runs.

So I created a docker-compose.yaml file and the build steps become much simpler.

```
# Build the image
docker compose up

# Build Release
docker compose run --rm builder ./make.sh

# Build Profile
docker compose run --rm builder ./make-profile.sh

# Build Debug
docker compose run --rm builder ./make-debug.sh
```